### PR TITLE
Add cargo tests to build process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ WORKDIR /app
 COPY Cargo.toml Cargo.lock ./
 COPY src ./src
 
+RUN cargo test
 RUN cargo build --verbose --release --target $(cat /rust_target.txt)
 
 # Move the binary to a location free of the target since that is not available in the next stage.

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ A dashboard is presented on `0.0.0.0:8000` that shows basic information for the 
 
 ## Usage
 
-### Storing events with bash
+### Storing events 
 
-An example of a bash script storing a new event can be found in the `examples/` directory.
+The `examples/` dir contains a bash script and a python script with examples for storing events.
 
 ### Docker Compose
 


### PR DESCRIPTION
- slight doc wording update
- cargo test is now called in dockerfile right before build