### PR TITLE
Use JSON in requests instead of form data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1670,6 +1670,7 @@ dependencies = [
  "rocket_codegen",
  "rocket_http",
  "serde",
+ "serde_json",
  "state",
  "tempfile",
  "time 0.3.14",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 rusqlite = { version = "^0.24.1", features = ["bundled"] }
 chrono = "0.4"
 rand = "0.5"
-rocket = "0.5.0-rc.2"
+rocket = {version = "0.5.0-rc.2", features = ["json"]}
 serde = "1.0"
 
 [dependencies.rocket_db_pools]

--- a/examples/bash_script.sh
+++ b/examples/bash_script.sh
@@ -1,8 +1,0 @@
-OUTPUT=$(restic --help 2>&1)
-CODE=$?
-
-curl -X POST \
-  -d "source=restic_backup_home_zac" \
-  -d "code=$CODE" \
-  --data-urlencode "output=$OUTPUT" \
-  http://0.0.0.0:8000/events/new

--- a/examples/python_script.py
+++ b/examples/python_script.py
@@ -3,14 +3,14 @@ import subprocess
 import requests
 
 backups = [
-  ('backup_1', 'restic --help'),
-  ('backup_2', 'restic --help')
+    ('backup_1', 'restic --help'),
+    ('backup_2', 'restic --help')
 ]
 
 for (name, command) in backups:
-  exit_code, output = subprocess.getstatusoutput(command)
-  requests.post('http://0.0.0.0:8000/events/new', data={
-    'source': name,
-    'code': exit_code,
-    'output': output
-  })
+    exit_code, output = subprocess.getstatusoutput(command)
+    requests.post('http://0.0.0.0:8000/events/new', json={
+        'source': name,
+        'code': exit_code,
+        'output': output
+    })

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -1,14 +1,17 @@
 pub use self::repo::Repo;
+use rocket::serde::Deserialize;
 use serde::ser::{Serialize, SerializeStruct, Serializer};
 
 mod repo;
 
-#[derive(Eq, PartialEq, Debug)]
+#[derive(Eq, PartialEq, Debug, Deserialize)]
 pub struct Event {
+    #[serde(skip_deserializing)]
     pub id: i32,
     pub source: String,
     pub code: i32,
     pub output: String,
+    #[serde(skip_deserializing)]
     pub date: String,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use chrono::Utc;
 use cronic::event::Event;
 use cronic::event::Repo;
-use rocket::form::Form;
+use rocket::serde::json::Json;
 use rocket::State;
 use rocket_dyn_templates::context;
 use rocket_dyn_templates::Template;
@@ -11,13 +11,6 @@ use std::sync::Mutex;
 
 #[macro_use]
 extern crate rocket;
-
-#[derive(FromForm)]
-struct UserInput {
-    source: String,
-    output: String,
-    code: i32,
-}
 
 struct EventRepoState {
     event_repo_mutex: Mutex<Repo>,
@@ -49,16 +42,16 @@ fn event(event_repo_state: &State<EventRepoState>, id: u32) -> Template {
     )
 }
 
-#[post("/new", data = "<user_input>")]
-fn new_event(event_repo_state: &State<EventRepoState>, user_input: Form<UserInput>) -> String {
+#[post("/new", format = "json", data = "<event>")]
+fn new_event(event_repo_state: &State<EventRepoState>, event: Json<Event>) -> String {
     let event_repo = event_repo_state.event_repo_mutex.lock().unwrap();
 
     event_repo
         .save(&vec![Event {
             id: 0,
-            source: user_input.source.clone(),
-            output: user_input.output.clone(),
-            code: user_input.code,
+            source: event.source.clone(),
+            output: event.output.clone(),
+            code: event.code,
             date: Utc::now().to_rfc2822(),
         }])
         .unwrap();


### PR DESCRIPTION
The web service is currently consuming the new event POST data as form data which has a 32kib default limit.
Rather than increasing this limit it makes more sense to migrate over to JSON as this was a design flaw to begin with.